### PR TITLE
v1 with full functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Focus Reader Chrome Extension
+
+A Chrome extension designed to help users with ADHD focus on their reading by highlighting the current paragraph and graying out the rest of the page.
+
+## Features
+
+- Toggle focus mode with Command+Shift+O (Mac) or Ctrl+Shift+O (Windows/Linux)
+- Single-click to select and highlight paragraphs
+- Use arrow keys (↑/↓) to navigate between paragraphs
+- Automatically grays out the rest of the page to minimize distractions
+- Smooth transitions and visual effects
+- Works on any webpage
+
+## Installation
+
+1. Download or clone this repository
+2. Open Chrome and go to `chrome://extensions/`
+3. Enable "Developer mode" in the top right corner
+4. Click "Load unpacked" and select the `focus-reader` folder
+5. The extension should now be installed and ready to use
+
+## Usage
+
+1. Navigate to any webpage you want to read
+2. Press Command+Shift+O (Mac) or Ctrl+Shift+O (Windows/Linux) to enable focus mode
+3. Click on any paragraph to highlight it
+4. Use up/down arrow keys to navigate between paragraphs
+5. The current paragraph will be highlighted while the rest of the page is grayed out
+6. Press Command+Shift+O (Mac) or Ctrl+Shift+O (Windows/Linux) again to disable focus mode
+
+## Notes
+
+- The extension works best with text-heavy pages
+- It automatically detects paragraphs, divs, and article elements
+- The highlight follows your cursor position and scroll position
+- When disabled, all highlights and overlays are removed 

--- a/background.js
+++ b/background.js
@@ -1,0 +1,13 @@
+chrome.commands.onCommand.addListener((command) => {
+    if (command === 'toggle-focus') {
+        chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+            if (tabs[0]) {
+                // Try to send the message
+                chrome.tabs.sendMessage(tabs[0].id, {action: 'toggle'})
+                    .catch(error => {
+                        console.log('Could not send message to content script:', error);
+                    });
+            }
+        });
+    }
+}); 

--- a/content.js
+++ b/content.js
@@ -1,0 +1,187 @@
+let currentParagraph = null;
+let overlay = null;
+let isEnabled = false;
+
+function createOverlay() {
+    overlay = document.createElement('div');
+    overlay.style.cssText = `
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.7);
+        z-index: 9998;
+        pointer-events: none;
+    `;
+    document.body.appendChild(overlay);
+}
+
+function findParagraphFromElement(element) {
+    // Find the nearest paragraph or image element
+    while (element && element.nodeType === Node.ELEMENT_NODE) {
+        if (element.tagName === 'P' || 
+            element.tagName === 'DIV' || 
+            element.tagName === 'ARTICLE' || 
+            element.tagName === 'SECTION' ||
+            element.tagName === 'LI' ||
+            element.tagName === 'IMG') {
+            return element;
+        }
+        element = element.parentNode;
+    }
+    return null;
+}
+
+function clearHighlight() {
+    if (currentParagraph) {
+        currentParagraph.style.backgroundColor = '';
+        currentParagraph.style.zIndex = '';
+        currentParagraph.style.border = '';
+        currentParagraph.classList.remove('focus-reader-highlight');
+        currentParagraph = null;
+    }
+}
+
+function updateHighlight(paragraph) {
+    if (!paragraph || !isEnabled) return;
+    
+    // Clear previous highlight
+    clearHighlight();
+    
+    // Apply new highlight
+    currentParagraph = paragraph;
+    
+    if (currentParagraph.tagName === 'IMG') {
+        // Special styling for images
+        currentParagraph.style.border = '4px solid white';
+        currentParagraph.style.boxShadow = '0 0 20px rgba(0, 0, 0, 0.5)';
+        currentParagraph.style.zIndex = '9999';
+        currentParagraph.style.position = 'relative';
+    } else {
+        // Original styling for text elements
+        currentParagraph.style.backgroundColor = 'white';
+        currentParagraph.style.zIndex = '9999';
+        currentParagraph.style.position = 'relative';
+        currentParagraph.classList.add('focus-reader-highlight');
+    }
+    
+    // Scroll to center the paragraph
+    const rect = currentParagraph.getBoundingClientRect();
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const viewportHeight = window.innerHeight;
+    const targetPosition = rect.top + scrollTop - (viewportHeight / 2) + (rect.height / 2);
+    
+    window.scrollTo({
+        top: targetPosition,
+        behavior: 'smooth'
+    });
+}
+
+function getAllParagraphs() {
+    const paragraphs = [];
+    const walker = document.createTreeWalker(
+        document.body,
+        NodeFilter.SHOW_ELEMENT,
+        {
+            acceptNode: function(node) {
+                if (node.tagName === 'P' || 
+                    node.tagName === 'DIV' || 
+                    node.tagName === 'ARTICLE' || 
+                    // node.tagName === 'SECTION' ||
+                    node.tagName === 'LI' ||
+                    node.tagName === 'IMG') {
+                    return NodeFilter.FILTER_ACCEPT;
+                }
+                return NodeFilter.FILTER_SKIP;
+            }
+        }
+    );
+    
+    let node;
+    while (node = walker.nextNode()) {
+        paragraphs.push(node);
+    }
+    
+    return paragraphs;
+}
+
+function findNextParagraph() {
+    if (!currentParagraph) return null;
+    
+    const allParagraphs = getAllParagraphs();
+    const currentIndex = allParagraphs.indexOf(currentParagraph);
+    
+    if (currentIndex === -1 || currentIndex === allParagraphs.length - 1) {
+        return null;
+    }
+    
+    return allParagraphs[currentIndex + 1];
+}
+
+function findPreviousParagraph() {
+    if (!currentParagraph) return null;
+    
+    const allParagraphs = getAllParagraphs();
+    const currentIndex = allParagraphs.indexOf(currentParagraph);
+    
+    if (currentIndex <= 0) {
+        return null;
+    }
+    
+    return allParagraphs[currentIndex - 1];
+}
+
+function handleClick(event) {
+    if (!isEnabled) return;
+    const clickedElement = event.target;
+    const paragraph = findParagraphFromElement(clickedElement);
+    updateHighlight(paragraph);
+}
+
+function handleKeyDown(event) {
+    if (!isEnabled) return;
+    
+    if (event.key === 'ArrowDown') {
+        event.preventDefault(); // Prevent default arrow key behavior
+        const nextParagraph = findNextParagraph();
+        if (nextParagraph) {
+            updateHighlight(nextParagraph);
+        }
+    } else if (event.key === 'ArrowUp') {
+        event.preventDefault(); // Prevent default arrow key behavior
+        const prevParagraph = findPreviousParagraph();
+        if (prevParagraph) {
+            updateHighlight(prevParagraph);
+        }
+    }
+}
+
+function toggleFocusMode() {
+    isEnabled = !isEnabled;
+    
+    if (isEnabled) {
+        if (!overlay) {
+            createOverlay();
+        }
+        overlay.style.display = 'block';
+    } else {
+        if (overlay) {
+            overlay.style.display = 'none';
+        }
+        clearHighlight();
+    }
+}
+
+// Listen for click events
+document.addEventListener('click', handleClick);
+
+// Listen for keyboard events
+document.addEventListener('keydown', handleKeyDown);
+
+// Listen for messages from background script
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === 'toggle') {
+        toggleFocusMode();
+    }
+}); 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 3,
+  "name": "Focus Reader",
+  "version": "1.0",
+  "description": "Helps users with ADHD focus on reading by highlighting the current paragraph and graying out the rest of the page",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "tabs"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "commands": {
+    "toggle-focus": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+O",
+        "mac": "Command+Shift+O"
+      },
+      "description": "Toggle focus mode"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "css": ["styles.css"]
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  }
+} 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,21 @@
+.focus-reader-highlight {
+    transition: all 0.3s ease;
+    padding: 15px;
+    margin: 10px 0;
+    border-radius: 8px;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+    background-color: white !important;
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.focus-reader-highlight p {
+    margin: 0;
+    line-height: 1.6;
+}
+
+.focus-reader-overlay {
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+} 


### PR DESCRIPTION
## Features

- Toggle focus mode with Command+Shift+O (Mac) or Ctrl+Shift+O (Windows/Linux)
- Single-click to select and highlight paragraphs
- Use arrow keys (↑/↓) to navigate between paragraphs
- Automatically grays out the rest of the page to minimize distractions
- Smooth transitions and visual effects
- Works on any webpage